### PR TITLE
Support ipv6

### DIFF
--- a/securetime/src/main/java/pl/tajchert/securetime/SecureTime.kt
+++ b/securetime/src/main/java/pl/tajchert/securetime/SecureTime.kt
@@ -5,6 +5,7 @@ import pl.tajchert.securetime.protocol.RtWire
 import pl.tajchert.securetime.util.BytesUtil
 import timber.log.Timber
 import java.math.BigInteger
+import java.net.Inet6Address
 import java.net.InetSocketAddress
 import java.net.StandardProtocolFamily
 import java.nio.ByteBuffer
@@ -35,7 +36,13 @@ public class SecureTime(
     fun getTime(): Triple<Instant, Int, Long> {
         val addr = InetSocketAddress(host, port)
 
-        val channel = DatagramChannel.open(StandardProtocolFamily.INET)
+        val family = if (addr.address is Inet6Address) {
+            StandardProtocolFamily.INET6
+        } else {
+            StandardProtocolFamily.INET
+        }
+
+        val channel = DatagramChannel.open(family)
         channel.configureBlocking(false)
 
         // Create a request message


### PR DESCRIPTION
There is a bug where it assumed all requests will be made to ipv4 ip, but it is possible an address can be resolved to an ipv6 ip, in which case it will fail, so this change will address this issue